### PR TITLE
mima: Add dependencies on script_latin and western_name_order.

### DIFF
--- a/mima/files.js
+++ b/mima/files.js
@@ -1,5 +1,5 @@
 {
-	"patch.js": 3351110907,
+	"patch.js": 3616395204,
 	"th13/face/Thumbs.db": 1291866594,
 	"th13/face/dummy.png": 2926711928,
 	"th13/face/pl01/Thumbs.db": 480155647,

--- a/mima/patch.js
+++ b/mima/patch.js
@@ -1,6 +1,8 @@
 {
 	"dependencies": [
-		"nmlgc/base_tsa"
+		"nmlgc/base_tsa",
+		"nmlgc/script_latin",
+		"nmlgc/western_name_order"
 	],
 	"id": "mima",
 	"servers": [


### PR DESCRIPTION
You definitely should have script_latin once your patch includes any text in
order to make it look prettier. Yes, the language patches include it
automatically, but this still allows users to get a nice Mima patch without
being forced to pick a translation from Touhou Patch Center.

Also adding western_name_order because you certainly want that as well.
